### PR TITLE
update node-midi dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/dinchak/node-easymidi",
   "dependencies": {
-    "midi": "^0.9.1"
+    "midi": "^0.9.4"
   },
   "devDependencies": {
     "chai": "^2.0.0",


### PR DESCRIPTION
Fix node-gyp issues due to old `nan` dependency in `node-midi`
